### PR TITLE
Penguins: fix indexes and home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,11 @@ gem "k_means"
 
 gem "fastimage"
 
+group :development do
+  gem "better_errors"
+  gem "binding_of_caller"
+end
+
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,13 +31,21 @@ GEM
       multi_json (~> 1.0)
     addressable (2.3.6)
     arel (3.0.3)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bson (1.9.2)
     bson_ext (1.9.2)
       bson (~> 1.9.2)
     builder (3.0.4)
+    coderay (1.1.0)
     dbscan (0.2)
       distance_measures
       geocoder
+    debug_inspector (0.0.2)
     distance_measures (0.0.6)
     erubis (2.7.0)
     fastimage (1.6.3)
@@ -114,6 +122,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bson_ext
   dbscan
   fastimage

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -22,9 +22,9 @@
 
 <h4>Most Classifications</h4>
 <div id="preview-gallery">
-  <% if (@recent_subject_ids.size > 0) %>
-    <% @recent_subject_ids.each do |id| %>
-      <div id="preview-recent-<%= id %>" class="preview-holder"></div>
+  <% if (@subject_ids.size > 0) %>
+    <% @subject_ids.each do |id| %>
+      <div id="preview-recent-<%= id %>" class="preview-holder">Loading…</div>
       <script type="text/javascript">
         $.ajax({
           url: "/subjects/preview/<%= id %>?eps=<%= @eps %>&min=<%= @min %>",

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,15 @@ module Milkman
 
     config.after_initialize do
         Subject.ensure_index [[:coords, 1]], :sparse => true
+        Subject.ensure_index [[:zooniverse_id, 1]], :sparse => true
+        Subject.ensure_index [['group.zooniverse_id', 1]], :sparse => true
+        Subject.ensure_index [['metadata.has_illustrations_count', 1]], :sparse => true
+        Subject.ensure_index [[:state, 1]], :sparse => true
+        Classification.ensure_index [[:subject_ids, 1]], :sparse => true
+        ScanResult.ensure_index [[:zooniverse_id, 1]], :sparse => true
+        ScanResult.ensure_index [[:state, 1]], :sparse => true
+        ScanResult.ensure_index [[:eps, 1]], :sparse => true
+        ScanResult.ensure_index [[:min, 1]], :sparse => true
     end
 
     # Configure sensitive parameters which will be filtered from the log file.


### PR DESCRIPTION
Add some mongoDB indexes to speed up queries.
Show the correct list of subjects under Most Classifications on home page.
